### PR TITLE
log levels defined that only logs of set LOGLEVEL env will appear

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,10 +11,9 @@ import (
 
  
 func main(){
-	if os.Getenv("MODE") == "debug" {
-		utils.RedirectLogs_toFile("debug.log", true)
-	}
-	utils.Debugf("htty application has started...")
+	//overwrite = true: flushes logfile each run
+	utils.RedirectLogs_toFile("htty.log", true)
+	utils.Infof("htty application has started...")
 
 	app := App{
 		sidePane: panels.SidePane{},

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -13,12 +13,18 @@ const (
 	LOG_WARN  = "warn"
 	LOG_ERROR = "error"
 	LOG_DEBUG = "debug"
+	LOG_ALL   = "all"
+	LOG_ENVNAME = "LOGLEVEL"
 )
 
 var logger = log.New(os.Stdout, "", 0)
+var devmodes = []string {LOG_INFO, LOG_WARN, LOG_ERROR, LOG_DEBUG, LOG_ALL}
 
 
 func Logf(level string, format string, args ...interface{}) {
+	if !assertAllowedLogLevel(level) {
+		return; 
+	}
 	ts := time.Now().Format("02-01-2006(15:04:05.000)")
 	//source = line that called this method
 	pc, _, line, ok := runtime.Caller(2)
@@ -45,19 +51,6 @@ func Errorf(format string, args ...interface{}) {
 	Logf(LOG_ERROR, format, args...)
 }
 
-func pathBase(fp string) string {
-	lastslash := -1
-	for id := len(fp) - 1; id >= 0; id-- {
-		if fp[id] == '/' {
-			lastslash = id
-			break
-		}
-	}
-	if lastslash >= 0 && lastslash+1 < len(fp) {
-		return fp[lastslash+1:]
-	}
-	return fp
-}
 
 //redirect the logs to some debug file (suggested use only during debug MODE)
 func RedirectLogs_toFile(outFile string, overwrite bool) *os.File {
@@ -73,4 +66,31 @@ func RedirectLogs_toFile(outFile string, overwrite bool) *os.File {
 	}
 	logger.SetOutput(logfile)
 	return logfile	
+}
+
+
+//check if the log is allowed in this "LOGLEVEL" 
+//(ex LOGLEVEL=all means allow all, LOGLEVEL=debug means allow only debug) 
+func assertAllowedLogLevel(level string) bool {
+	if os.Getenv(LOG_ENVNAME) == LOG_ALL {
+		return true;	
+	}		
+	if os.Getenv(LOG_ENVNAME) == level {
+		return true;	
+	}
+	return false
+}
+
+func pathBase(fp string) string {
+	lastslash := -1
+	for id := len(fp) - 1; id >= 0; id-- {
+		if fp[id] == '/' {
+			lastslash = id
+			break
+		}
+	}
+	if lastslash >= 0 && lastslash+1 < len(fp) {
+		return fp[lastslash+1:]
+	}
+	return fp
 }


### PR DESCRIPTION
**ex:** 
- `LOGLEVEL=debug go run .` will show only debug level logs in htty.log file
- `LOGLEVEL=all go run .` will show all level logs (info, debug, warn, error) in htty.log file